### PR TITLE
Add Homebrew Formula

### DIFF
--- a/HomebrewFormula/gifme.rb
+++ b/HomebrewFormula/gifme.rb
@@ -1,0 +1,16 @@
+class Gifme < Formula
+  desc "Wrapper for ffmpeg to ease the creation of high-quality gifs from videos"
+  homepage "https://github.com/scottpham/gifme"
+  url "https://github.com/scottpham/gifme.git",
+    :revision => "456756e9ca7f8a359417a8a91bbfacb7a4b0924b"
+  version "1"
+  head "https://github.com/scottpham/gifme.git"
+
+  bottle :unneeded
+
+  depends_on "ffmpeg"
+
+  def install
+    bin.install "gifme.sh" => "gifme"
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -54,3 +54,10 @@ A number 1-3 representing desired Bayer Scale dithering filter. The Bayer Scale 
 
 - -o DITHERING OFF  
 Turns off dithering. Do not use this option with -b or the results may be unexpected.
+
+## Installation
+
+MacOS with Homebrew:
+
+    brew tap scottpham/gifme git@github.com:scottpham/gifme.git
+    brew instll gifme


### PR DESCRIPTION
This will allow for installation via Homebrew.

Unfortunately, Homebrew has a notoriety requirement to end up in the main formula repository. Also, because of how `homebrew` expects the repo to be named, we have to supply the full repo URL.